### PR TITLE
Update index.ios.js

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -20,6 +20,7 @@ const iconNames = {
 	Clouds: 'md-cloudy' ,
 	Snow: 'md-snow' ,
 	Drizzle: 'md-umbrella' ,
+	Mist: 'md-partly-sunny'
 }
 
 const phrases = {
@@ -69,6 +70,13 @@ const phrases = {
 		title: "Meh... don't even ask",
 		subtitle: "What did I just say?",
 		highlight: "don't",
+		color: "#B3F6E4",
+		background: "#1FBB68"
+	},
+	Mist: {
+		title: "Mist title",
+		subtitle: "Mist sub",
+		highlight: "Mist",
 		color: "#B3F6E4",
 		background: "#1FBB68"
 	},


### PR DESCRIPTION
Didn't find the "Mist" response in the [API docs](http://openweathermap.org/weather-conditions), but I had "Mist" returned during testing as a main weather category. It seems as though there is a parent category for each weather group (2xx, 3xx, etc), even though not all are listed.